### PR TITLE
feat: add reproducible dataset split config

### DIFF
--- a/Symlink_Work/config.yaml
+++ b/Symlink_Work/config.yaml
@@ -1,0 +1,6 @@
+seed: 42
+splits:
+  train: 70
+  val: 20
+  test: 10
+dataset_root: /home/user/your_dataset

--- a/Symlink_Work/prepare_task_symlinks.py
+++ b/Symlink_Work/prepare_task_symlinks.py
@@ -3,7 +3,21 @@ import random
 import yaml
 from pathlib import Path
 
-def split_and_symlink(task_path: Path, val_ratio=0.2, test_ratio=0.1):
+
+def split_and_symlink(task_path: Path, cfg: dict, rng: random.Random) -> None:
+    """Split dataset files and create symlinks based on a config.
+
+    Parameters
+    ----------
+    task_path: Path
+        Path to the task directory containing ``images/Train`` and ``labels/Train``.
+    cfg: dict
+        Configuration dictionary with ``splits`` and ``seed``.
+    rng: random.Random
+        Random number generator initialised with ``cfg['seed']`` to ensure
+        reproducible shuffling.
+    """
+
     img_train = task_path / "images/Train"
     lbl_train = task_path / "labels/Train"
     assert img_train.exists() and lbl_train.exists(), "Missing folder"
@@ -13,17 +27,19 @@ def split_and_symlink(task_path: Path, val_ratio=0.2, test_ratio=0.1):
         (task_path / f"images/{split}").mkdir(parents=True, exist_ok=True)
         (task_path / f"labels/{split}").mkdir(parents=True, exist_ok=True)
 
-    # Get image files
+    # Get image files and deterministically shuffle
     image_files = list(img_train.glob("*.jpg")) + list(img_train.glob("*.png"))
-    random.shuffle(image_files)
+    rng.shuffle(image_files)
 
     total = len(image_files)
+    val_ratio = cfg["splits"]["val"] / 100
+    test_ratio = cfg["splits"]["test"] / 100
     val_count = int(total * val_ratio)
     test_count = int(total * test_ratio)
 
     val_files = image_files[:val_count]
-    test_files = image_files[val_count:val_count + test_count]
-    train_files = image_files[val_count + test_count:]
+    test_files = image_files[val_count : val_count + test_count]
+    train_files = image_files[val_count + test_count :]
 
     def link(files, split):
         for img_path in files:
@@ -44,14 +60,32 @@ def split_and_symlink(task_path: Path, val_ratio=0.2, test_ratio=0.1):
         "val": "images/val",
         "test": "images/test",
         "nc": 2,  # You may need to update this with the actual number of classes
-        "names": ["car", "truck"]  # Replace with actual class names
+        "names": ["car", "truck"],  # Replace with actual class names
     }
     with open(task_path / "data.yaml", "w") as f:
         yaml.dump(new_data, f)
 
+    # Save split metadata for reproducibility
+    meta = {
+        "seed": cfg["seed"],
+        "total_images": total,
+        "train": len(train_files),
+        "val": len(val_files),
+        "test": len(test_files),
+    }
+    with open(task_path / "split_meta.yaml", "w") as f:
+        yaml.dump(meta, f)
+
     print(f"{task_path.name}/data.yaml updated ✅\n")
 
-# Apply to all tasks
-root_dir = Path("/home/user/your_dataset")  # this should contain the path to your original dataset
+
+# Load configuration
+with open(Path(__file__).parent / "config.yaml") as f:
+    CONFIG = yaml.safe_load(f)
+
+stable_random = random.Random(CONFIG.get("seed", 42))
+root_dir = Path(CONFIG.get("dataset_root", "/home/user/your_dataset"))
+
+# Apply to all tasks using a stable RNG
 for task in root_dir.glob("task_*"):
-    split_and_symlink(task)
+    split_and_symlink(task, CONFIG, stable_random)

--- a/Symlink_Work/symlink_guide.md
+++ b/Symlink_Work/symlink_guide.md
@@ -37,23 +37,21 @@ kendi_datasetiniz/
 
 This script performs the following steps for each task folder:
 
-1. **Finds image files**: Scans for .jpg and .png files in the Train folder
-2. **Shuffles randomly**: Splits data objectively
-3. **Splits according to ratios**:
-   - Test: %10
-   - Validation: %20  
-   - Train: %70
-4. **Creates symlinks**: Uses symbolic links instead of copying files (saves disk space)
-5. **Generates data.yaml**: Required configuration file for YOLO
+1. **Reads configuration**: `config.yaml` defines split ratios, dataset path and a random seed.
+2. **Finds image files**: Scans for `.jpg` and `.png` files in the `Train` folder.
+3. **Shuffles deterministically**: Uses a stable RNG seeded from the config for reproducible splits.
+4. **Splits according to ratios**: Defaults are Test %10, Validation %20 and Train %70.
+5. **Creates symlinks**: Uses symbolic links instead of copying files (saves disk space).
+6. **Generates data.yaml and metadata**: Creates required YOLO config and `split_meta.yaml` with counts and seed.
 
 ### Usage
 
-1. Edit the path in the script:
-```python
-root_dir = Path("/home/user/your_dataset")  # Replace with your own path
-```
+1. Edit the values in `config.yaml`:
+   - `dataset_root`: Path to the dataset containing `task_*` folders.
+   - `seed`: Seed value for reproducible shuffling.
+   - `splits`: Train/val/test percentages.
 
-2. Update class information:
+2. Update class information inside `prepare_task_symlinks.py` if needed:
 ```python
 "nc": 2,  # Number of classes
 "names": ["car", "truck"]  # Your actual class names
@@ -80,7 +78,8 @@ task_1/
 │   ├── train/           # Symlinks
 │   ├── val/             # Symlinks
 │   └── test/            # Symlinks
-└── data.yaml            # YOLO config file
+├── data.yaml            # YOLO config file
+└── split_meta.yaml      # Metadata containing seed and file counts
 ```
 
 ## Step 2: Merging the Final Dataset


### PR DESCRIPTION
## Summary
- load train/val/test ratios and seed from `config.yaml`
- deterministically shuffle files with a stable RNG and save split metadata
- document config-driven workflow for symlink-based dataset prep

## Testing
- `python -m py_compile Symlink_Work/prepare_task_symlinks.py`


------
https://chatgpt.com/codex/tasks/task_e_6893375bcf408324b6c01582d214c314